### PR TITLE
fix: fixed DST bug

### DIFF
--- a/populate-scripts/update-db.sql
+++ b/populate-scripts/update-db.sql
@@ -2911,6 +2911,8 @@ UPDATE tasks set
             },
             {
                 "component": "DISPLAYCOMPONENT",
+                "skippable": true,
+                "skippableCacheKey": "demandselection-should-skip",
                 "content": {
                     "title": "",
                     "sections": [


### PR DESCRIPTION
The DST practice includes 2 parts:
1) the participant does the practice trials
2) if the participant gets under a certain threshold correct, then they have to redo the practice trials.

The info display slide showing the # of trials correct for the redo was always showing. This means that the participant would see a repeated slide. if the participant got all correct (or above the threshold), they would see the points they scored twice.

This PR fixes the above issue.